### PR TITLE
Update napari to 0.6.1

### DIFF
--- a/napari_requirements.txt
+++ b/napari_requirements.txt
@@ -1,3 +1,3 @@
 dask
 imageio_ffmpeg
-napari[all]==0.4.18
+napari[all]==0.6.1


### PR DESCRIPTION
## Summary
- bump napari requirement to 0.6.1

## Testing
- `pytest -q` *(fails: pydantic ValidationError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_685e85b779b48322a92997f18116726b