### PR TITLE
Fix sidebar menu overlap and logout spacing

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -10,3 +10,19 @@
     max-width: 1000px;
 }
 
+/* Adjust the mobile menu button position when the sidebar is visible */
+.nav-overlay-icon {
+    position: relative;
+    left: 0;
+    transition: left 0.25s ease-in-out;
+}
+
+#__navigation:checked ~ .page .nav-overlay-icon {
+    left: 15em; /* match sidebar width */
+}
+
+/* Ensure the last sidebar item (e.g., logout) has spacing from the bottom */
+.sidebar-drawer li:last-child {
+    margin-bottom: 1rem;
+}
+


### PR DESCRIPTION
## Summary
- adjust mobile menu button when sidebar is open
- add extra bottom spacing for last sidebar item

## Testing
- `pytest -q` *(fails: ValidationError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68615ed02f1c8322bc4d832693984fad