### PR TITLE
Revert CSS sidebar menu change

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -10,19 +10,3 @@
     max-width: 1000px;
 }
 
-/* Adjust the mobile menu button position when the sidebar is visible */
-.nav-overlay-icon {
-    position: relative;
-    left: 0;
-    transition: left 0.25s ease-in-out;
-}
-
-#__navigation:checked ~ .page .nav-overlay-icon {
-    left: 15em; /* match sidebar width */
-}
-
-/* Ensure the last sidebar item (e.g., logout) has spacing from the bottom */
-.sidebar-drawer li:last-child {
-    margin-bottom: 1rem;
-}
-


### PR DESCRIPTION
## Summary
- revert sidebar CSS modifications

## Testing
- `pytest -q` *(fails: pydantic ValidationError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6861694134fc8322bb1ebf6262b22acb